### PR TITLE
Add expected hours/day, real-time homepage stats

### DIFF
--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -1,21 +1,47 @@
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { Navigate } from 'react-router-dom'
 import { useAuth } from '../contexts/AuthContext'
+import { db } from '../firebase'
+import { collection, getDocs, getCountFromServer, query, where } from 'firebase/firestore'
 
 export default function HomePage() {
   const { isAuthenticated, activeRole, availableRoles, loginWithGoogle, loading } = useAuth()
   const [error, setError] = useState(null)
   const [loggingIn, setLoggingIn] = useState(false)
+  const [stats, setStats] = useState({ positions: 0, applications: 0, companies: 0 })
 
-  // If authenticated with a role, redirect to dashboard
+  useEffect(() => {
+    async function fetchStats() {
+      try {
+        const openQ = query(collection(db, 'internships'), where('status', '==', 'open'))
+        const [internSnap, appSnap] = await Promise.all([
+          getCountFromServer(openQ),
+          getCountFromServer(collection(db, 'applications')),
+        ])
+        const allInterns = await getDocs(collection(db, 'internships'))
+        const companies = new Set()
+        allInterns.forEach(doc => {
+          const company = doc.data().company
+          if (company) companies.add(company)
+        })
+        setStats({
+          positions: internSnap.data().count,
+          applications: appSnap.data().count,
+          companies: companies.size,
+        })
+      } catch {
+        // Stats are non-critical, keep defaults
+      }
+    }
+    fetchStats()
+  }, [])
+
   if (isAuthenticated && activeRole) {
     return <Navigate to={`/${activeRole}`} replace />
   }
-  // If authenticated with multiple roles, go to role select
   if (isAuthenticated && availableRoles.length > 0) {
     return <Navigate to="/select-role" replace />
   }
-  // If authenticated but no roles assigned yet, go to role select (shows pending approval)
   if (isAuthenticated && !loading) {
     return <Navigate to="/select-role" replace />
   }
@@ -28,8 +54,6 @@ export default function HomePage() {
       setError(result.error)
       setLoggingIn(false)
     }
-    // On success, onAuthStateChanged handles the rest and isAuthenticated becomes true,
-    // triggering a redirect above on re-render
   }
 
   return (
@@ -150,9 +174,9 @@ export default function HomePage() {
 
         <div style={{ display: 'flex', gap: 20, flexWrap: 'wrap', justifyContent: 'center', marginTop: 8 }}>
           {[
-            { value: '50+', label: 'Active Positions' },
-            { value: '200+', label: 'Applications' },
-            { value: '30+', label: 'Partner Companies' },
+            { value: stats.positions, label: 'Open Positions' },
+            { value: stats.applications, label: 'Applications' },
+            { value: stats.companies, label: 'Partner Companies' },
           ].map(({ value, label }) => (
             <div key={label} style={{
               background: 'rgba(255,255,255,0.08)',
@@ -178,9 +202,9 @@ export default function HomePage() {
         width: '100%',
       }}>
         {[
-          { icon: '🎓', title: 'For Students (10th Grade - College)', desc: 'Browse internships, apply online, and track your application status. Open to students from 10th grade through college.' },
-          { icon: '🏢', title: 'For Employers', desc: 'Post opportunities, review applicants, and manage your hiring pipeline with AI-powered tools.' },
-          { icon: '⚙️', title: 'For Admins', desc: 'Oversee the program, manage users, assign coordinators, and view comprehensive analytics.' },
+          { icon: '\ud83c\udf93', title: 'For Students (10th Grade - College)', desc: 'Browse internships, apply online, and track your application status. Open to students from 10th grade through college.' },
+          { icon: '\ud83c\udfe2', title: 'For Employers', desc: 'Post opportunities, review applicants, and manage your hiring pipeline with AI-powered tools.' },
+          { icon: '\u2699\ufe0f', title: 'For Admins', desc: 'Oversee the program, manage users, assign coordinators, and view comprehensive analytics.' },
         ].map(({ icon, title, desc }) => (
           <div key={title} style={{
             background: 'rgba(255,255,255,0.06)',

--- a/src/pages/employer/EmployerNewPosting.jsx
+++ b/src/pages/employer/EmployerNewPosting.jsx
@@ -34,6 +34,7 @@ export default function EmployerNewPosting() {
     preferredQualifications: '',
     skills: '',
     benefits: '',
+    expectedHoursPerDay: '',
     applicationDeadline: '',
     startDate: '',
     additionalNotes: '',
@@ -105,6 +106,7 @@ export default function EmployerNewPosting() {
         positions: parseInt(form.positions) || 1,
         gradeLevelMin: form.gradeLevelMin,
         gradeLevelMax: form.gradeLevelMax || null,
+        expectedHoursPerDay: form.expectedHoursPerDay,
         contactEmail: form.contactEmail,
         contactPhone: form.contactPhone,
       })
@@ -240,6 +242,17 @@ export default function EmployerNewPosting() {
                 <option value="12 months">12 months</option>
               </select>
             </div>
+          </div>
+          <div className="form-group">
+            <label>Expected Hours Per Day <span className="required">*</span></label>
+            <select className="form-control" name="expectedHoursPerDay" value={form.expectedHoursPerDay} onChange={handleChange} required>
+              <option value="">Select...</option>
+              <option value="1-2 hours">1-2 hours</option>
+              <option value="2-4 hours">2-4 hours</option>
+              <option value="4-6 hours">4-6 hours</option>
+              <option value="6-8 hours">6-8 hours</option>
+              <option value="Flexible">Flexible</option>
+            </select>
           </div>
           <div className="form-row">
             <div className="form-group">

--- a/src/pages/intern/InternBrowse.jsx
+++ b/src/pages/intern/InternBrowse.jsx
@@ -77,6 +77,7 @@ export default function InternBrowse() {
               <div style={{ display: 'flex', gap: 16, margin: '12px 0', fontSize: 13, color: 'var(--nriva-text-light)' }}>
                 <span>📍 {job.location}</span>
                 <span>⏱ {job.duration}</span>
+                {job.expectedHoursPerDay && <span>🕐 {job.expectedHoursPerDay}/day</span>}
                 <span>🕐 {job.type}</span>
                 <span>💰 {job.stipend}</span>
               </div>

--- a/src/pages/intern/InternDashboard.jsx
+++ b/src/pages/intern/InternDashboard.jsx
@@ -47,7 +47,7 @@ export default function InternDashboard() {
         <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 16 }}>
           <h2 style={{ fontSize: 18, fontWeight: 600 }}>My Recent Applications</h2>
           <Link to="/intern/applications" style={{ color: 'var(--nriva-primary)', fontSize: 14, fontWeight: 500 }}>
-            View All \u2192
+            View All →
           </Link>
         </div>
         <div className="table-wrapper">
@@ -82,7 +82,7 @@ export default function InternDashboard() {
         <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 16 }}>
           <h2 style={{ fontSize: 18, fontWeight: 600 }}>Recommended for You</h2>
           <Link to="/intern/browse" style={{ color: 'var(--nriva-primary)', fontSize: 14, fontWeight: 500 }}>
-            Browse All \u2192
+            Browse All →
           </Link>
         </div>
         <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(300px, 1fr))', gap: 16 }}>
@@ -100,10 +100,10 @@ export default function InternDashboard() {
                 <span className="badge badge-open">Open</span>
               </div>
               <div style={{ display: 'flex', gap: 12, margin: '12px 0', fontSize: 12, color: 'var(--nriva-text-light)' }}>
-                <span>\ud83d\udccd {job.location}</span>
-                <span>\u23f1 {job.duration}</span>
-                {job.expectedHoursPerDay && <span>\ud83d\udd50 {job.expectedHoursPerDay}/day</span>}
-                <span>\ud83d\udcb0 {job.stipend}</span>
+                <span>📍 {job.location}</span>
+                <span>⏱ {job.duration}</span>
+                {job.expectedHoursPerDay && <span>🕐 {job.expectedHoursPerDay}/day</span>}
+                <span>💰 {job.stipend}</span>
               </div>
               <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap', marginBottom: 12 }}>
                 {job.skills.slice(0, 3).map(s => (

--- a/src/pages/intern/InternDashboard.jsx
+++ b/src/pages/intern/InternDashboard.jsx
@@ -47,7 +47,7 @@ export default function InternDashboard() {
         <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 16 }}>
           <h2 style={{ fontSize: 18, fontWeight: 600 }}>My Recent Applications</h2>
           <Link to="/intern/applications" style={{ color: 'var(--nriva-primary)', fontSize: 14, fontWeight: 500 }}>
-            View All →
+            View All \u2192
           </Link>
         </div>
         <div className="table-wrapper">
@@ -82,7 +82,7 @@ export default function InternDashboard() {
         <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 16 }}>
           <h2 style={{ fontSize: 18, fontWeight: 600 }}>Recommended for You</h2>
           <Link to="/intern/browse" style={{ color: 'var(--nriva-primary)', fontSize: 14, fontWeight: 500 }}>
-            Browse All →
+            Browse All \u2192
           </Link>
         </div>
         <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(300px, 1fr))', gap: 16 }}>
@@ -100,9 +100,10 @@ export default function InternDashboard() {
                 <span className="badge badge-open">Open</span>
               </div>
               <div style={{ display: 'flex', gap: 12, margin: '12px 0', fontSize: 12, color: 'var(--nriva-text-light)' }}>
-                <span>📍 {job.location}</span>
-                <span>⏱ {job.duration}</span>
-                <span>💰 {job.stipend}</span>
+                <span>\ud83d\udccd {job.location}</span>
+                <span>\u23f1 {job.duration}</span>
+                {job.expectedHoursPerDay && <span>\ud83d\udd50 {job.expectedHoursPerDay}/day</span>}
+                <span>\ud83d\udcb0 {job.stipend}</span>
               </div>
               <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap', marginBottom: 12 }}>
                 {job.skills.slice(0, 3).map(s => (

--- a/src/seed.js
+++ b/src/seed.js
@@ -23,6 +23,7 @@ const testInternships = [
     deadline: '2026-06-30',
     status: 'open',
     positions: 3,
+    expectedHoursPerDay: '6-8 hours',
     contactEmail: 'rajesh@techvasavi.com',
   },
   {
@@ -42,6 +43,7 @@ const testInternships = [
     deadline: '2026-05-31',
     status: 'open',
     positions: 2,
+    expectedHoursPerDay: '4-6 hours',
     contactEmail: 'priya@databridge.com',
   },
   {
@@ -61,6 +63,7 @@ const testInternships = [
     deadline: '2026-07-15',
     status: 'open',
     positions: 2,
+    expectedHoursPerDay: '2-4 hours',
     contactEmail: 'lakshmi@nriva.org',
   },
   {
@@ -80,6 +83,7 @@ const testInternships = [
     deadline: '2026-05-15',
     status: 'open',
     positions: 2,
+    expectedHoursPerDay: '6-8 hours',
     contactEmail: 'venkat@cloudnine.io',
   },
   {
@@ -99,6 +103,7 @@ const testInternships = [
     deadline: '2026-06-01',
     status: 'open',
     positions: 1,
+    expectedHoursPerDay: '2-4 hours',
     contactEmail: 'anita@creativevasavi.com',
   },
   {
@@ -118,6 +123,7 @@ const testInternships = [
     deadline: '2026-05-30',
     status: 'open',
     positions: 1,
+    expectedHoursPerDay: '6-8 hours',
     contactEmail: 'suresh@nriva.org',
   },
   {
@@ -137,6 +143,7 @@ const testInternships = [
     deadline: '2026-06-15',
     status: 'open',
     positions: 2,
+    expectedHoursPerDay: '6-8 hours',
     contactEmail: 'kiran@appvasavi.com',
   },
   {
@@ -156,6 +163,7 @@ const testInternships = [
     deadline: '2026-07-01',
     status: 'open',
     positions: 3,
+    expectedHoursPerDay: '4-6 hours',
     contactEmail: 'deepa@greenfuture.org',
   },
   {
@@ -175,6 +183,7 @@ const testInternships = [
     deadline: '2026-06-01',
     status: 'open',
     positions: 2,
+    expectedHoursPerDay: '6-8 hours',
     contactEmail: 'ramesh@vasavihealth.com',
   },
   {
@@ -194,6 +203,7 @@ const testInternships = [
     deadline: '2026-07-31',
     status: 'open',
     positions: 3,
+    expectedHoursPerDay: '2-4 hours',
     contactEmail: 'meena@nrivamedia.org',
   },
 ]


### PR DESCRIPTION
## Changes\n- Add expected hours per day field to employer posting form\n- Show hours/day in internship listings (browse and dashboard)\n- Replace hardcoded homepage stats with real-time Firestore counts\n- Update seed data with hours per day values\n\nhttps://claude.ai/code/session_01CnDsNdGt4YJpGroVGK2dCe