### PR TITLE
Self-service onboarding, app limit, email notifications

### DIFF
--- a/api/notify-signup.js
+++ b/api/notify-signup.js
@@ -1,0 +1,87 @@
+// Vercel serverless function to send signup notification email
+// Uses Resend (https://resend.com) or falls back to storing in Firestore
+// Set RESEND_API_KEY in Vercel env vars to enable email sending
+// If no email service configured, notifications are stored in Firestore 'notifications' collection
+
+export default async function handler(req, res) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'Method not allowed' })
+  }
+
+  const { userName, userEmail, requestedRole, nrivaMembership } = req.body || {}
+  const adminEmail = 'kalyank.123@gmail.com'
+
+  // Try Resend if configured
+  const resendKey = process.env.RESEND_API_KEY
+  if (resendKey) {
+    try {
+      const response = await fetch('https://api.resend.com/emails', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${resendKey}`,
+        },
+        body: JSON.stringify({
+          from: 'NRIVA Internship Portal <noreply@nriva.org>',
+          to: adminEmail,
+          subject: `New Signup: ${userName} (${requestedRole})`,
+          html: `
+            <h2>New User Signup - NRIVA Internship Portal</h2>
+            <table style="border-collapse:collapse;width:100%;max-width:500px">
+              <tr><td style="padding:8px;border:1px solid #e2e8f0;font-weight:bold">Name</td><td style="padding:8px;border:1px solid #e2e8f0">${userName || 'Not provided'}</td></tr>
+              <tr><td style="padding:8px;border:1px solid #e2e8f0;font-weight:bold">Email</td><td style="padding:8px;border:1px solid #e2e8f0">${userEmail || 'Not provided'}</td></tr>
+              <tr><td style="padding:8px;border:1px solid #e2e8f0;font-weight:bold">Requested Role</td><td style="padding:8px;border:1px solid #e2e8f0">${requestedRole || 'Not specified'}</td></tr>
+              <tr><td style="padding:8px;border:1px solid #e2e8f0;font-weight:bold">NRIVA Membership</td><td style="padding:8px;border:1px solid #e2e8f0">${nrivaMembership || 'None'}</td></tr>
+            </table>
+            ${requestedRole !== 'intern' ? '<p style="margin-top:16px;color:#b45309"><strong>Action Required:</strong> This user requested the ' + requestedRole + ' role which requires your approval. Log in to the admin portal to review.</p>' : '<p style="margin-top:16px;color:#15803d">This user was auto-approved as an intern.</p>'}
+            <p style="margin-top:16px"><a href="https://azurenetwork.vercel.app">Open Admin Portal</a></p>
+          `,
+        }),
+      })
+      if (response.ok) {
+        return res.status(200).json({ sent: true, method: 'resend' })
+      }
+    } catch (err) {
+      console.error('Resend email failed:', err)
+    }
+  }
+
+  // Fallback: use EmailJS if configured
+  const emailjsKey = process.env.EMAILJS_PUBLIC_KEY
+  const emailjsService = process.env.EMAILJS_SERVICE_ID
+  const emailjsTemplate = process.env.EMAILJS_TEMPLATE_ID
+  if (emailjsKey && emailjsService && emailjsTemplate) {
+    try {
+      const response = await fetch('https://api.emailjs.com/api/v1.0/email/send', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          service_id: emailjsService,
+          template_id: emailjsTemplate,
+          user_id: emailjsKey,
+          template_params: {
+            to_email: adminEmail,
+            from_name: 'NRIVA Internship Portal',
+            subject: `New Signup: ${userName} (${requestedRole})`,
+            user_name: userName,
+            user_email: userEmail,
+            requested_role: requestedRole,
+            membership: nrivaMembership || 'None',
+          },
+        }),
+      })
+      if (response.ok) {
+        return res.status(200).json({ sent: true, method: 'emailjs' })
+      }
+    } catch (err) {
+      console.error('EmailJS failed:', err)
+    }
+  }
+
+  // No email service configured - notification stored in Firestore by client
+  return res.status(200).json({
+    sent: false,
+    method: 'firestore_only',
+    message: 'No email service configured. Notification stored in Firestore. Set RESEND_API_KEY or EMAILJS_* env vars to enable email.',
+  })
+}

--- a/firestore.rules
+++ b/firestore.rules
@@ -39,5 +39,11 @@ service cloud.firestore {
       allow create: if request.auth != null;
       allow update, delete: if false;
     }
+    match /notifications/{docId} {
+      allow read: if isAdmin();
+      allow create: if request.auth != null;
+      allow update: if isAdmin();
+      allow delete: if false;
+    }
   }
 }

--- a/src/contexts/AuthContext.jsx
+++ b/src/contexts/AuthContext.jsx
@@ -19,6 +19,7 @@ export function AuthProvider({ children }) {
   const [activeRole, setActiveRole] = useState(null)
   const [loading, setLoading] = useState(true)
   const [userCoordinator, setUserCoordinator] = useState(null)
+  const [onboarded, setOnboarded] = useState(false)
 
   useEffect(() => {
     const unsubscribe = onAuthChange(async (firebaseUser) => {
@@ -56,6 +57,7 @@ export function AuthProvider({ children }) {
           const roles = getUserRoles(firebaseUser.email, firestoreUser.roles || [])
           setAvailableRoles(roles)
           setUserCoordinator(firestoreUser.coordinator || null)
+          setOnboarded(firestoreUser.onboarded || false)
 
           const savedRole = localStorage.getItem(`nriva_role_${firebaseUser.uid}`)
           if (savedRole && roles.includes(savedRole)) {
@@ -112,6 +114,7 @@ export function AuthProvider({ children }) {
     setAvailableRoles([])
     setActiveRole(null)
     setUserCoordinator(null)
+    setOnboarded(false)
   }
 
   return (
@@ -121,6 +124,7 @@ export function AuthProvider({ children }) {
       activeRole,
       loading,
       userCoordinator,
+      onboarded,
       loginWithGoogle,
       loginWithEmail,
       signUp,

--- a/src/pages/RoleSelectPage.jsx
+++ b/src/pages/RoleSelectPage.jsx
@@ -1,38 +1,44 @@
-import { Link, useNavigate } from 'react-router-dom'
-import { useEffect } from 'react'
+import { useState, useEffect } from 'react'
+import { useNavigate } from 'react-router-dom'
 import { useAuth } from '../contexts/AuthContext'
+import { onboardUser, sendAdminNotification } from '../services/firestore'
 
 const roleConfig = [
   {
     id: 'intern',
     title: 'Intern',
-    description: 'Browse and apply for internship positions',
+    description: 'Browse and apply for internship positions (10th grade - college)',
     icon: '🎓',
     color: '#1a237e',
+    autoApproved: true,
   },
   {
     id: 'employer',
     title: 'Employer',
-    description: 'Post opportunities and manage applicants',
+    description: 'Post internship opportunities and manage applicants',
     icon: '🏢',
     color: '#1b5e20',
+    autoApproved: false,
   },
   {
     id: 'admin',
     title: 'Administrator',
-    description: 'Oversee the entire internship program',
+    description: 'Oversee the internship program and manage users',
     icon: '⚙️',
     color: '#b71c1c',
+    autoApproved: false,
   },
 ]
 
 export default function RoleSelectPage() {
-  const { user, availableRoles, selectRole, logout } = useAuth()
+  const { user, availableRoles, selectRole, logout, refreshRoles } = useAuth()
   const navigate = useNavigate()
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState(null)
 
   const visibleRoles = roleConfig.filter(r => availableRoles.includes(r.id))
+  const isNewUser = availableRoles.length === 0
 
-  // Auto-redirect if only one role
   useEffect(() => {
     if (visibleRoles.length === 1) {
       selectRole(visibleRoles[0].id)
@@ -45,119 +51,246 @@ export default function RoleSelectPage() {
     navigate(`/${roleId}`)
   }
 
-  if (availableRoles.length === 0) {
-    return (
-      <div style={{
-        minHeight: '100vh',
-        background: 'linear-gradient(135deg, #0d1642 0%, #1a237e 50%, #283593 100%)',
-        display: 'flex',
-        flexDirection: 'column',
-        alignItems: 'center',
-        justifyContent: 'center',
-        padding: 20,
-      }}>
-        <div style={{
-          background: 'white',
-          borderRadius: 20,
-          padding: '48px 36px',
-          maxWidth: 440,
-          width: '100%',
-          textAlign: 'center',
-        }}>
-          <div style={{ fontSize: 48, marginBottom: 16 }}>⏳</div>
-          <h2 style={{ fontSize: 22, fontWeight: 700, color: '#1a237e', marginBottom: 12 }}>
-            Account Pending Approval
-          </h2>
-          <p style={{ color: '#64748b', fontSize: 14, lineHeight: 1.6, marginBottom: 8 }}>
-            Your account has been created successfully. An NRIVA administrator
-            will review your account and assign roles shortly.
-          </p>
-          <p style={{ color: '#94a3b8', fontSize: 13, marginBottom: 24 }}>
-            Contact: admin@nriva.org
-          </p>
-          <button
-            onClick={async () => { await logout(); navigate('/') }}
-            style={{
-              background: '#1a237e', color: 'white', border: 'none',
-              padding: '10px 24px', borderRadius: 8, fontSize: 14,
-              fontWeight: 500, cursor: 'pointer',
-            }}
-          >
-            Sign Out
-          </button>
-        </div>
-      </div>
-    )
+  // New user onboarding form
+  if (isNewUser) {
+    return <OnboardingForm user={user} logout={logout} navigate={navigate}
+      selectRole={selectRole} refreshRoles={refreshRoles}
+      submitting={submitting} setSubmitting={setSubmitting}
+      error={error} setError={setError} />
   }
+
+  // Existing user with roles - show role selection
+  return (
+    <div style={{
+      minHeight: '100vh',
+      background: 'linear-gradient(135deg, #0d1642 0%, #1a237e 50%, #283593 100%)',
+      display: 'flex', flexDirection: 'column',
+      alignItems: 'center', justifyContent: 'center', padding: 20,
+    }}>
+      <div style={{ textAlign: 'center', marginBottom: 32, color: 'white' }}>
+        <img src="/nriva-logo.svg" alt="NRIVA"
+          style={{ width: 80, height: 80, objectFit: 'contain', marginBottom: 16 }}
+          onError={(e) => { e.target.style.display = 'none' }} />
+        <h1 style={{ fontSize: 24, fontWeight: 700, marginBottom: 8 }}>
+          Welcome, {user?.displayName || 'User'}!
+        </h1>
+        <p style={{ opacity: 0.7, fontSize: 15 }}>Select your role to continue</p>
+      </div>
+
+      <div style={{ display: 'flex', gap: 20, flexWrap: 'wrap', justifyContent: 'center', maxWidth: 800 }}>
+        {visibleRoles.map((role) => (
+          <button key={role.id} onClick={() => handleSelect(role.id)}
+            style={{
+              background: 'white', borderRadius: 16, padding: '32px 28px',
+              width: 220, border: '2px solid transparent',
+              cursor: 'pointer', textAlign: 'center', transition: 'all 0.3s',
+            }}
+            onMouseEnter={(e) => { e.currentTarget.style.transform = 'translateY(-4px)'; e.currentTarget.style.boxShadow = '0 20px 40px rgba(0,0,0,0.2)'; e.currentTarget.style.borderColor = role.color }}
+            onMouseLeave={(e) => { e.currentTarget.style.transform = 'translateY(0)'; e.currentTarget.style.boxShadow = 'none'; e.currentTarget.style.borderColor = 'transparent' }}>
+            <div style={{ fontSize: 40, marginBottom: 12 }}>{role.icon}</div>
+            <h3 style={{ fontSize: 18, fontWeight: 700, color: role.color, marginBottom: 8 }}>{role.title}</h3>
+            <p style={{ fontSize: 13, color: '#64748b', lineHeight: 1.5 }}>{role.description}</p>
+          </button>
+        ))}
+      </div>
+
+      <button onClick={() => window.history.back()}
+        style={{ color: 'rgba(255,255,255,0.5)', fontSize: 13, marginTop: 24, background: 'none', border: 'none', cursor: 'pointer' }}>
+        Go back
+      </button>
+    </div>
+  )
+}
+
+function OnboardingForm({ user, logout, navigate, selectRole, refreshRoles, submitting, setSubmitting, error, setError }) {
+  const [selectedRole, setSelectedRole] = useState('')
+  const [membership, setMembership] = useState('')
+  const [displayName, setDisplayName] = useState(user?.displayName || '')
+
+  const handleSubmit = async (e) => {
+    e.preventDefault()
+    if (!selectedRole) { setError('Please select a role'); return }
+    if (!displayName.trim()) { setError('Please enter your name'); return }
+
+    setSubmitting(true)
+    setError(null)
+    try {
+      const roles = await onboardUser(user.uid, {
+        requestedRole: selectedRole,
+        nrivaMembership: membership.trim(),
+        displayName: displayName.trim(),
+      })
+
+      // Send notification to admin about new signup (email + Firestore)
+      const notifyData = {
+        userName: displayName.trim(),
+        userEmail: user.email,
+        requestedRole: selectedRole,
+        nrivaMembership: membership.trim() || 'None',
+        userUid: user.uid,
+      }
+      try {
+        await sendAdminNotification({ type: 'new_signup', ...notifyData })
+        // Also try email via serverless function
+        fetch('/api/notify-signup', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(notifyData),
+        }).catch(() => {})
+      } catch {
+        // Notification is best-effort
+      }
+
+      // Refresh auth context to get updated roles
+      await refreshRoles()
+
+      if (selectedRole === 'intern') {
+        selectRole('intern')
+        navigate('/intern', { replace: true })
+      } else {
+        // Employer/admin need approval - show pending message
+        setSubmitting(false)
+      }
+    } catch (err) {
+      setError(err.message || 'Failed to save. Please try again.')
+      setSubmitting(false)
+    }
+  }
+
+  const selectedConfig = roleConfig.find(r => r.id === selectedRole)
 
   return (
     <div style={{
       minHeight: '100vh',
       background: 'linear-gradient(135deg, #0d1642 0%, #1a237e 50%, #283593 100%)',
-      display: 'flex',
-      flexDirection: 'column',
-      alignItems: 'center',
-      justifyContent: 'center',
-      padding: 20,
+      display: 'flex', flexDirection: 'column',
+      alignItems: 'center', justifyContent: 'center', padding: 20,
     }}>
-      <div style={{ textAlign: 'center', marginBottom: 32, color: 'white' }}>
-        <img
-          src="/nriva-logo.svg"
-          alt="NRIVA"
-          style={{ width: 80, height: 80, objectFit: 'contain', marginBottom: 16 }}
-          onError={(e) => { e.target.style.display = 'none' }}
-        />
-        <h1 style={{ fontSize: 24, fontWeight: 700, marginBottom: 8 }}>
-          Welcome, {user?.displayName || 'User'}!
-        </h1>
-        <p style={{ opacity: 0.7, fontSize: 15 }}>
-          Select your role to continue
-        </p>
-      </div>
+      <div style={{
+        background: 'white', borderRadius: 20, padding: '36px 32px',
+        maxWidth: 520, width: '100%',
+      }}>
+        <div style={{ textAlign: 'center', marginBottom: 24 }}>
+          <img src="/nriva-logo.svg" alt="NRIVA"
+            style={{ width: 60, height: 60, objectFit: 'contain', marginBottom: 12 }}
+            onError={(e) => { e.target.style.display = 'none' }} />
+          <h2 style={{ fontSize: 22, fontWeight: 700, color: '#1a237e', marginBottom: 4 }}>
+            Welcome to NRIVA Internship Program!
+          </h2>
+          <p style={{ color: '#64748b', fontSize: 14 }}>
+            Tell us about yourself to get started
+          </p>
+        </div>
 
-      <div style={{ display: 'flex', gap: 20, flexWrap: 'wrap', justifyContent: 'center', maxWidth: 800 }}>
-        {visibleRoles.map((role) => (
-          <button
-            key={role.id}
-            onClick={() => handleSelect(role.id)}
-            style={{
-              background: 'white',
-              borderRadius: 16,
-              padding: '32px 28px',
-              width: 220,
-              border: '2px solid transparent',
-              cursor: 'pointer',
-              textAlign: 'center',
-              transition: 'all 0.3s',
-            }}
-            onMouseEnter={(e) => {
-              e.currentTarget.style.transform = 'translateY(-4px)'
-              e.currentTarget.style.boxShadow = '0 20px 40px rgba(0,0,0,0.2)'
-              e.currentTarget.style.borderColor = role.color
-            }}
-            onMouseLeave={(e) => {
-              e.currentTarget.style.transform = 'translateY(0)'
-              e.currentTarget.style.boxShadow = 'none'
-              e.currentTarget.style.borderColor = 'transparent'
-            }}
-          >
-            <div style={{ fontSize: 40, marginBottom: 12 }}>{role.icon}</div>
-            <h3 style={{ fontSize: 18, fontWeight: 700, color: role.color, marginBottom: 8 }}>
-              {role.title}
-            </h3>
-            <p style={{ fontSize: 13, color: '#64748b', lineHeight: 1.5 }}>
-              {role.description}
+        <form onSubmit={handleSubmit}>
+          <div style={{ marginBottom: 16 }}>
+            <label style={{ display: 'block', fontWeight: 500, fontSize: 14, marginBottom: 6 }}>
+              Full Name <span style={{ color: '#c62828' }}>*</span>
+            </label>
+            <input type="text" value={displayName} onChange={(e) => setDisplayName(e.target.value)}
+              placeholder="Your full name" required
+              style={inputStyle} />
+          </div>
+
+          <div style={{ marginBottom: 16 }}>
+            <label style={{ display: 'block', fontWeight: 500, fontSize: 14, marginBottom: 6 }}>
+              Email
+            </label>
+            <input type="email" value={user?.email || ''} disabled
+              style={{ ...inputStyle, background: '#f8fafc', color: '#94a3b8' }} />
+          </div>
+
+          <div style={{ marginBottom: 16 }}>
+            <label style={{ display: 'block', fontWeight: 500, fontSize: 14, marginBottom: 6 }}>
+              NRIVA Membership ID
+            </label>
+            <input type="text" value={membership} onChange={(e) => setMembership(e.target.value)}
+              placeholder="e.g., NRIVA-12345 (optional)"
+              style={inputStyle} />
+            <p style={{ fontSize: 12, color: '#64748b', marginTop: 4, lineHeight: 1.5 }}>
+              Don&apos;t have one? Sign up at{' '}
+              <a href="https://nriva.org/membership" target="_blank" rel="noopener noreferrer"
+                style={{ color: '#1a237e', fontWeight: 500 }}>
+                nriva.org/membership
+              </a>
             </p>
-          </button>
-        ))}
-      </div>
+            <p style={{ fontSize: 12, color: '#b45309', marginTop: 4, fontStyle: 'italic' }}>
+              * Life members will be given priority for internship placements
+            </p>
+          </div>
 
-      <button
-        onClick={() => window.history.back()}
-        style={{ color: 'rgba(255,255,255,0.5)', fontSize: 13, marginTop: 24, background: 'none', border: 'none', cursor: 'pointer' }}
-      >
-        Go back
-      </button>
+          <div style={{ marginBottom: 20 }}>
+            <label style={{ display: 'block', fontWeight: 500, fontSize: 14, marginBottom: 10 }}>
+              I want to join as <span style={{ color: '#c62828' }}>*</span>
+            </label>
+            <div style={{ display: 'flex', gap: 12, flexWrap: 'wrap' }}>
+              {roleConfig.filter(r => r.id !== 'admin').map((role) => (
+                <button key={role.id} type="button"
+                  onClick={() => setSelectedRole(role.id)}
+                  style={{
+                    flex: 1, minWidth: 140, padding: '16px 12px',
+                    borderRadius: 12, textAlign: 'center',
+                    border: `2px solid ${selectedRole === role.id ? role.color : '#e2e8f0'}`,
+                    background: selectedRole === role.id ? `${role.color}10` : 'white',
+                    cursor: 'pointer', transition: 'all 0.2s',
+                  }}>
+                  <div style={{ fontSize: 28, marginBottom: 6 }}>{role.icon}</div>
+                  <div style={{ fontSize: 14, fontWeight: 600, color: role.color }}>{role.title}</div>
+                  <div style={{ fontSize: 11, color: '#64748b', marginTop: 4 }}>
+                    {role.autoApproved ? '✓ Instant access' : 'Requires approval'}
+                  </div>
+                </button>
+              ))}
+            </div>
+          </div>
+
+          {selectedConfig && !selectedConfig.autoApproved && (
+            <div style={{
+              background: '#fffbeb', border: '1px solid #fde68a', borderRadius: 8,
+              padding: '10px 14px', fontSize: 13, color: '#92400e', marginBottom: 16,
+            }}>
+              The {selectedConfig.title.toLowerCase()} role requires admin approval. You&apos;ll be notified once approved.
+            </div>
+          )}
+
+          {error && (
+            <div style={{
+              background: '#fef2f2', border: '1px solid #fecaca', borderRadius: 8,
+              padding: '10px 14px', fontSize: 13, color: '#dc2626', marginBottom: 16,
+            }}>
+              {error}
+            </div>
+          )}
+
+          <button type="submit" disabled={submitting || !selectedRole}
+            style={{
+              width: '100%', padding: '14px 20px', borderRadius: 10,
+              border: 'none', fontSize: 15, fontWeight: 600, cursor: 'pointer',
+              background: selectedRole ? '#1a237e' : '#e2e8f0',
+              color: selectedRole ? 'white' : '#94a3b8',
+              opacity: submitting ? 0.6 : 1,
+              transition: 'all 0.2s',
+            }}>
+            {submitting ? 'Setting up your account...' :
+              selectedRole === 'intern' ? 'Get Started as Intern' :
+              selectedRole ? `Request ${selectedConfig?.title} Access` :
+              'Select a role above'}
+          </button>
+
+          <button type="button" onClick={async () => { await logout(); navigate('/') }}
+            style={{
+              width: '100%', marginTop: 12, padding: '10px', border: 'none',
+              background: 'none', color: '#64748b', fontSize: 13, cursor: 'pointer',
+            }}>
+            Sign Out
+          </button>
+        </form>
+      </div>
     </div>
   )
+}
+
+const inputStyle = {
+  width: '100%', padding: '11px 14px', borderRadius: 8,
+  border: '1px solid #e2e8f0', fontSize: 14, boxSizing: 'border-box',
 }

--- a/src/pages/intern/InternApply.jsx
+++ b/src/pages/intern/InternApply.jsx
@@ -2,7 +2,7 @@ import { useState } from 'react'
 import { useParams, useNavigate } from 'react-router-dom'
 import { useAuth } from '../../contexts/AuthContext'
 import { useInternships } from '../../hooks/useFirestore'
-import { createApplication, GRADE_LEVELS } from '../../services/firestore'
+import { createApplication, getApplicationCount, GRADE_LEVELS, MAX_INTERN_APPLICATIONS } from '../../services/firestore'
 import { uploadResume } from '../../firebase'
 import Toast from '../../components/Toast'
 
@@ -57,6 +57,16 @@ export default function InternApply() {
     if (!form.gradeLevel) {
       setToast('Please select your current grade level')
       return
+    }
+    // Check application limit
+    try {
+      const count = await getApplicationCount(user.uid)
+      if (count >= MAX_INTERN_APPLICATIONS) {
+        setToast(`You have reached the maximum of ${MAX_INTERN_APPLICATIONS} applications. Please withdraw an existing application before applying to new positions.`)
+        return
+      }
+    } catch {
+      // Continue if check fails
     }
     // Validate grade level against internship requirements
     if (internship?.gradeLevelMin) {

--- a/src/pages/intern/InternDashboard.jsx
+++ b/src/pages/intern/InternDashboard.jsx
@@ -1,6 +1,7 @@
 import { Link } from 'react-router-dom'
 import { useAuth } from '../../contexts/AuthContext'
 import { useInternships, useApplications } from '../../hooks/useFirestore'
+import { MAX_INTERN_APPLICATIONS } from '../../services/firestore'
 import { formatDate } from '../../utils/date'
 
 export default function InternDashboard() {
@@ -9,6 +10,7 @@ export default function InternDashboard() {
   const { data: allInternships } = useInternships()
   const myApplications = allApplications.slice(0, 3)
   const recommended = allInternships.filter(i => i.status === 'open').slice(0, 3)
+  const remainingApps = Math.max(0, MAX_INTERN_APPLICATIONS - allApplications.length)
 
   return (
     <div>
@@ -27,7 +29,10 @@ export default function InternDashboard() {
       <div className="stats-grid">
         <div className="stat-card">
           <div className="stat-label">Applications Submitted</div>
-          <div className="stat-value">{allApplications.length}</div>
+          <div className="stat-value">{allApplications.length} <span style={{ fontSize: 14, fontWeight: 400, color: 'var(--nriva-text-light)' }}>/ {MAX_INTERN_APPLICATIONS}</span></div>
+          <div style={{ fontSize: 12, color: remainingApps === 0 ? 'var(--nriva-danger)' : 'var(--nriva-text-light)', marginTop: 4 }}>
+            {remainingApps === 0 ? 'Maximum reached' : `${remainingApps} remaining`}
+          </div>
         </div>
         <div className="stat-card">
           <div className="stat-label">Under Review</div>

--- a/src/services/firestore.js
+++ b/src/services/firestore.js
@@ -25,6 +25,8 @@ export const INTERNSHIP_STATUSES = {
   REJECTED: 'rejected',
 }
 
+export const MAX_INTERN_APPLICATIONS = 4
+
 // ============ ACTIVITY LOG ============
 
 export async function logActivity(action, data = {}) {
@@ -68,12 +70,49 @@ export async function createUser(uid, data) {
     photoURL: data.photoURL || '',
     roles: [],
     coordinator: null,
+    onboarded: false,
+    nrivaMembership: '',
+    requestedRole: '',
     createdAt: serverTimestamp(),
     updatedAt: serverTimestamp(),
   }
   await setDoc(userRef, userData)
   logActivity('user_signup', { userUid: uid, email: data.email, displayName: data.displayName })
   return userData
+}
+
+export async function onboardUser(uid, { requestedRole, nrivaMembership, displayName }) {
+  const updates = {
+    onboarded: true,
+    requestedRole,
+    nrivaMembership: nrivaMembership || '',
+    updatedAt: serverTimestamp(),
+  }
+  if (displayName) updates.displayName = displayName
+  // Intern role is auto-approved
+  if (requestedRole === 'intern') {
+    updates.roles = ['intern']
+  }
+  await updateDoc(doc(db, 'users', uid), updates)
+  logActivity('user_onboarded', { userUid: uid, requestedRole, nrivaMembership })
+  return requestedRole === 'intern' ? ['intern'] : []
+}
+
+export async function getApplicationCount(applicantUid) {
+  const q = query(collection(db, 'applications'), where('applicantUid', '==', applicantUid))
+  const snap = await getDocs(q)
+  return snap.size
+}
+
+export async function sendAdminNotification(data) {
+  // Store as a notification doc - can be picked up by a Cloud Function to send email
+  await addDoc(collection(db, 'notifications'), {
+    to: SUPER_ADMIN_EMAIL,
+    type: data.type || 'new_signup',
+    ...data,
+    sent: false,
+    createdAt: serverTimestamp(),
+  })
 }
 
 export async function getUser(uid) {


### PR DESCRIPTION
## Summary

- **Self-service onboarding**: New users see a role selection form on first login. Intern role is auto-approved; employer/admin require approval. Collects NRIVA membership ID and full name.
- **Application limit**: Interns are capped at 4 applications max. Count is displayed on the dashboard with remaining slots.
- **Email notifications**: Added `/api/notify-signup` serverless endpoint that sends admin email on new signups via Resend or EmailJS, with Firestore fallback.

## Files Changed

- `src/services/firestore.js` - onboardUser, getApplicationCount, sendAdminNotification, MAX_INTERN_APPLICATIONS
- `src/contexts/AuthContext.jsx` - onboarded state, refreshRoles
- `src/pages/RoleSelectPage.jsx` - OnboardingForm with role picker and NRIVA membership
- `firestore.rules` - notifications collection rules
- `src/pages/intern/InternApply.jsx` - application limit check before submit
- `src/pages/intern/InternDashboard.jsx` - show app count / max on dashboard
- `api/notify-signup.js` - Vercel serverless email notification endpoint